### PR TITLE
41: Integrate DeepSource test coverage reporting

### DIFF
--- a/.deepsource.toml
+++ b/.deepsource.toml
@@ -1,10 +1,20 @@
 version = 1
 
+test_patterns = [
+    "**/test/**"
+]
+
+exclude_patterns = [
+    "build/**"
+]
+
 [[analyzers]]
 name = "sql"
+enabled = true
 
 [[analyzers]]
 name = "kotlin"
+enabled = true
 
   [analyzers.meta]
   runtime_version = "17"
@@ -12,3 +22,4 @@ name = "kotlin"
 
 [[analyzers]]
 name = "test-coverage"
+enabled = true

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -39,26 +39,15 @@ jobs:
       - name: Build App with Gradle
         run: ./gradlew assembleDebug
 
-      - name: Run Kover XML Report and Report to DeepSource
+      - name: Run Kover XML Report
+        run: ./gradlew koverXmlReport
+
+      - name: Report Kover Report to DeepSource
         run: |
-          echo "Running Kover XML reporting job"
-          ./gradlew :koverXmlReport
-          echo "Tests have finished, here are the `ls` command results"
-          ls
-          echo "Tests have finished, here are the `ls ${{ github.workspace }}` command results"
-          ls ${{ github.workspace }}
-          echo "Tests have finished, here are the `ls build` command results"
-          ls build
-          echo "Tests have finished, here are the `ls build/reports` command results"
-          ls build/reports
-          echo "Tests have finished, here are the `ls build/reports/kover` command results"
-          ls build/reports/kover
-          echo "Tests have finished, here are the `ls build/reports/kover/xml` command results"
-          ls build/reports/kover/xml
           echo "Install deepsource CLI"
           curl https://deepsource.io/cli | sh
           # From the root directory, run the report coverage command
-           ./bin/deepsource report --analyzer test-coverage --key kotlin --value-file ${{ github.workspace }}/build/reports/kover/xml/report.xml
+          ./bin/deepsource report --analyzer test-coverage --key kotlin --value-file ${{ github.workspace }}/build/reports/kover/report.xml
         env:
           DEEPSOURCE_DSN: ${{ secrets.DEEPSOURCE_DSN }}
 

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -39,8 +39,8 @@ jobs:
       - name: Build App with Gradle
         run: ./gradlew build
 
-      - name: Run Unit Tests
-        run: ./gradlew testDebugUnitTest
+      - name: Run Kover XML Report
+        run: ./gradlew koverXmlReport
 
       - name: Debug Environment
         run: echo "DEEPSOURCE_DSN=${{ secrets.DEEPSOURCE_DSN }}, SERVICE_ACCOUNT=${{ secrets.SERVICE_ACCOUNT }}"

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -6,6 +6,9 @@ jobs:
   build:
     name: Build and Test
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      secrets: write
 
     steps:
       - name: Checkout Repository
@@ -41,6 +44,9 @@ jobs:
 
       - name: Run Unit Tests
         run: ./gradlew testDebugUnitTest
+
+      - name: Debug Environment
+        run: echo "DEEPSOURCE_DSN=${{ secrets.DEEPSOURCE_DSN }}, SERVICE_ACCOUNT=${{ secrets.SERVICE_ACCOUNT }}"
 
       - name: Report test coverage to DeepSource
         run: |

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -37,23 +37,20 @@ jobs:
         run: chmod +x ./gradlew
 
       - name: Build App with Gradle
-        run: ./gradlew build
-
-      - name: Debug Environment
-        run: |
-          pwd
-          ls
-          echo "DEEPSOURCE_DSN=${{ secrets.DEEPSOURCE_DSN }}, SERVICE_ACCOUNT=${{ secrets.SERVICE_ACCOUNT }}"
+        run: ./gradlew assembleDebug
 
       - name: Run Kover XML Report and Report to DeepSource
         run: |
-          pwd
-          ls
-          # Running Kover XML reporting job
+          echo "Running Kover XML reporting job"
           ./gradlew :koverXmlReport
-          # Tests have finished and a test coverage report is available
-          # Install deepsource CLI
-           curl https://deepsource.io/cli | sh
+          echo "Tests have finished, here are the ls command results"
+          ls
+          ls build
+          ls build/reports
+          ls build/reports/kover
+          ls build/reports/kover/xml
+          echo "Install deepsource CLI"
+          curl https://deepsource.io/cli | sh
           # From the root directory, run the report coverage command
            ./bin/deepsource report --analyzer test-coverage --key kotlin --value-file build/reports/kover/xml/report.xml
         env:

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -6,9 +6,6 @@ jobs:
   build:
     name: Build and Test
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      secrets: write
 
     steps:
       - name: Checkout Repository

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -39,14 +39,18 @@ jobs:
       - name: Build App with Gradle
         run: ./gradlew build
 
-      - name: Run Kover XML Report
-        run: ./gradlew koverXmlReport
-
       - name: Debug Environment
-        run: echo "DEEPSOURCE_DSN=${{ secrets.DEEPSOURCE_DSN }}, SERVICE_ACCOUNT=${{ secrets.SERVICE_ACCOUNT }}"
-
-      - name: Report test coverage to DeepSource
         run: |
+          pwd
+          ls
+          echo "DEEPSOURCE_DSN=${{ secrets.DEEPSOURCE_DSN }}, SERVICE_ACCOUNT=${{ secrets.SERVICE_ACCOUNT }}"
+
+      - name: Run Kover XML Report and Report to DeepSource
+        run: |
+          pwd
+          ls
+          # Running Kover XML reporting job
+          ./gradlew :koverXmlReport
           # Tests have finished and a test coverage report is available
           # Install deepsource CLI
            curl https://deepsource.io/cli | sh

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -42,6 +42,16 @@ jobs:
       - name: Run Unit Tests
         run: ./gradlew testDebugUnitTest
 
+      - name: Report test coverage to DeepSource
+        run: |
+          # Tests have finished and a test coverage report is available
+          # Install deepsource CLI
+           curl https://deepsource.io/cli | sh
+          # From the root directory, run the report coverage command
+           ./bin/deepsource report --analyzer test-coverage --key kotlin --value-file build/reports/kover/xml/report.xml
+        env:
+          DEEPSOURCE_DSN: ${{ secrets.DEEPSOURCE_DSN }}
+
 # FIXME: Temporary disabled, should be re-enabled when CI is configured and stable
 #    - name: Build Android Test APK
 #      run: ./gradlew assembleAndroidTest

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -43,16 +43,22 @@ jobs:
         run: |
           echo "Running Kover XML reporting job"
           ./gradlew :koverXmlReport
-          echo "Tests have finished, here are the ls command results"
+          echo "Tests have finished, here are the `ls` command results"
           ls
+          echo "Tests have finished, here are the `ls ${{ github.workspace }}` command results"
+          ls ${{ github.workspace }}
+          echo "Tests have finished, here are the `ls build` command results"
           ls build
+          echo "Tests have finished, here are the `ls build/reports` command results"
           ls build/reports
+          echo "Tests have finished, here are the `ls build/reports/kover` command results"
           ls build/reports/kover
+          echo "Tests have finished, here are the `ls build/reports/kover/xml` command results"
           ls build/reports/kover/xml
           echo "Install deepsource CLI"
           curl https://deepsource.io/cli | sh
           # From the root directory, run the report coverage command
-           ./bin/deepsource report --analyzer test-coverage --key kotlin --value-file build/reports/kover/xml/report.xml
+           ./bin/deepsource report --analyzer test-coverage --key kotlin --value-file ${{ github.workspace }}/build/reports/kover/xml/report.xml
         env:
           DEEPSOURCE_DSN: ${{ secrets.DEEPSOURCE_DSN }}
 

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -52,13 +52,12 @@ jobs:
         env:
           DEEPSOURCE_DSN: ${{ secrets.DEEPSOURCE_DSN }}
 
-# FIXME: Temporary disabled, should be re-enabled when CI is configured and stable
-#    - name: Build Android Test APK
-#      run: ./gradlew assembleAndroidTest
+      - name: Build Android Test APK
+        run: ./gradlew assembleAndroidTest
 
-#    - name: Run Android tests on Firebase Test Lab
-#      uses: asadmansr/Firebase-Test-Lab-Action@v1.0
-#      with:
-#        arg-spec: 'android-device.yml:android-pixel-5'
-#      env:
-#        SERVICE_ACCOUNT: ${{ secrets.SERVICE_ACCOUNT }}
+      - name: Run Android tests on Firebase Test Lab
+        uses: asadmansr/Firebase-Test-Lab-Action@v1.0
+        with:
+          arg-spec: 'android-device.yml:android-pixel-5'
+        env:
+          SERVICE_ACCOUNT: ${{ secrets.SERVICE_ACCOUNT }}

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -10,6 +10,8 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Set up JDK 21
         uses: actions/setup-java@v4

--- a/.github/workflows/conditional-merge.yml
+++ b/.github/workflows/conditional-merge.yml
@@ -20,9 +20,11 @@ on:
 jobs:
   check:
     uses: ./.github/workflows/check.yml
+    secrets: inherit
 
   lint:
     uses: ./.github/workflows/lint.yml
+    secrets: inherit
 
   merge:
     name: Auto Merge

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,8 +1,12 @@
+import org.gradle.api.tasks.testing.logging.TestExceptionFormat
+import org.gradle.api.tasks.testing.logging.TestLogEvent
+
 plugins {
     id("com.vocabri.android.application")
     alias(libs.plugins.compose.compiler)
     alias(libs.plugins.google.services)
     alias(libs.plugins.firebase.crashlytics)
+    id("com.vocabri.kover")
 }
 
 android {
@@ -60,6 +64,14 @@ android {
     testOptions {
         unitTests {
             isIncludeAndroidResources = true
+            all {
+                it.testLogging {
+                    events = setOf(
+                        TestLogEvent.FAILED,
+                    )
+                    exceptionFormat = TestExceptionFormat.FULL
+                }
+            }
         }
     }
 }

--- a/build-logic/convention/build.gradle.kts
+++ b/build-logic/convention/build.gradle.kts
@@ -34,5 +34,9 @@ gradlePlugin {
             id = "com.vocabri.android.library"
             implementationClass = "AndroidLibraryConventionPlugin"
         }
+        register("kover") {
+            id = "com.vocabri.kover"
+            implementationClass = "KoverConventionPlugin"
+        }
     }
 }

--- a/build-logic/convention/src/main/kotlin/KoverConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/KoverConventionPlugin.kt
@@ -1,0 +1,11 @@
+import com.vocabri.applyKover
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+
+class KoverConventionPlugin : Plugin<Project> {
+    override fun apply(target: Project) {
+        with(target) {
+            applyKover()
+        }
+    }
+}

--- a/build-logic/convention/src/main/kotlin/com/vocabri/KoverConfiguration.kt
+++ b/build-logic/convention/src/main/kotlin/com/vocabri/KoverConfiguration.kt
@@ -1,0 +1,24 @@
+package com.vocabri
+
+import kotlinx.kover.gradle.plugin.KoverGradlePlugin
+import kotlinx.kover.gradle.plugin.dsl.KoverProjectExtension
+import kotlinx.kover.gradle.plugin.dsl.KoverReportFiltersConfig
+import org.gradle.api.Project
+import org.gradle.kotlin.dsl.apply
+
+fun Project.applyKover() {
+    pluginManager.apply(KoverGradlePlugin::class)
+    extensions.configure<KoverProjectExtension>("kover") {
+        reports {
+            filters {
+                coverageExclusions()
+            }
+        }
+    }
+}
+
+private fun KoverReportFiltersConfig.coverageExclusions() {
+    excludes {
+        androidGeneratedClasses()
+    }
+}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,7 +7,13 @@ plugins {
     alias(libs.plugins.google.services) apply false
     alias(libs.plugins.firebase.crashlytics) apply false
     alias(libs.plugins.detekt) apply false
-    alias(libs.plugins.kover) apply false
     alias(libs.plugins.spotless) apply false
+    alias(libs.plugins.kover)
     id("com.vocabri.project")
+}
+
+dependencies {
+    kover(projects.app)
+    kover(projects.data)
+    kover(projects.domain)
 }

--- a/data/build.gradle.kts
+++ b/data/build.gradle.kts
@@ -1,6 +1,10 @@
+import org.gradle.api.tasks.testing.logging.TestExceptionFormat
+import org.gradle.api.tasks.testing.logging.TestLogEvent
+
 plugins {
     id("com.vocabri.android.library")
     alias(libs.plugins.sqldelight)
+    id("com.vocabri.kover")
 }
 
 android {
@@ -38,6 +42,20 @@ android {
             excludes += "/META-INF/{AL2.0,LGPL2.1}"
             merges += "META-INF/LICENSE.md"
             merges += "META-INF/LICENSE-notice.md"
+        }
+    }
+
+    testOptions {
+        unitTests {
+            isIncludeAndroidResources = true
+            all {
+                it.testLogging {
+                    events = setOf(
+                        TestLogEvent.FAILED,
+                    )
+                    exceptionFormat = TestExceptionFormat.FULL
+                }
+            }
         }
     }
 }

--- a/domain/build.gradle.kts
+++ b/domain/build.gradle.kts
@@ -1,10 +1,23 @@
+import org.gradle.api.tasks.testing.logging.TestExceptionFormat
+import org.gradle.api.tasks.testing.logging.TestLogEvent
+
 plugins {
     alias(libs.plugins.kotlin)
+    id("com.vocabri.kover")
 }
 
 kotlin {
     jvmToolchain {
         languageVersion.set(JavaLanguageVersion.of(21))
+    }
+}
+
+tasks.test {
+    testLogging {
+        events = setOf(
+            TestLogEvent.FAILED,
+        )
+        exceptionFormat = TestExceptionFormat.FULL
     }
 }
 


### PR DESCRIPTION
This commit integrates DeepSource test coverage reporting into the CI pipeline.

- Adds a step to the check workflow to report test coverage to DeepSource using the DeepSource CLI.
- Applies the Kover plugin to the app, data, and domain modules.
- Configures Kover to generate coverage reports and exclude specific files.
- Includes Android resources in unit tests for more comprehensive coverage.
- Updates build logic to support Kover integration.

closes #41 